### PR TITLE
try with search

### DIFF
--- a/keepassxc/keepassxc_db.py
+++ b/keepassxc/keepassxc_db.py
@@ -124,7 +124,7 @@ class KeepassxcDatabase:
         if self.is_passphrase_needed():
             raise KeepassxcLockedDbError()
 
-        (err, out) = self.run_cli("locate", "-q", self.path, query)
+        (err, out) = self.run_cli("search", "-q", self.path, query)
         if err:
             if "No results for that" in err:
                 return []

--- a/keepassxc/keepassxc_db.py
+++ b/keepassxc/keepassxc_db.py
@@ -124,7 +124,9 @@ class KeepassxcDatabase:
         if self.is_passphrase_needed():
             raise KeepassxcLockedDbError()
 
-        (err, out) = self.run_cli("search", "-q", self.path, query)
+        (err, out) = self.run_cli("locate", "-q", self.path, query)
+        if err:
+            (err, out) = self.run_cli("search", "-q", self.path, query)
         if err:
             if "No results for that" in err:
                 return []


### PR DESCRIPTION
The new version of keepassxc-cli does not support `locate` command anymore.

So this Pull request adds the code to try with search command if it fails:

![image](https://github.com/pbkhrv/ulauncher-keepassxc/assets/851942/1454e108-3f86-4548-96bf-30a100c9c8ed)

